### PR TITLE
ath79: add support to TrendNet TEW-673GRU 

### DIFF
--- a/target/linux/ath79/dts/ar7161_trendnet_tew-673gru.dts
+++ b/target/linux/ath79/dts/ar7161_trendnet_tew-673gru.dts
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar7100.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "trendnet,tew-673gru", "qca,ar7161";
+	model = "TRENDNET TEW-673GRU";
+
+	aliases {
+		led-boot = &wps;
+		led-failsafe = &wps;
+		led-running = &wps;
+		led-upgrade = &wps;
+	};
+
+	extosc: ref {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-output-names = "ref";
+		clock-frequency = <40000000>;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wps: wps {
+			label = "blue:wps";
+			gpios = <&gpio 9 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	ath9k-leds {
+		compatible = "gpio-leds";
+
+		wlan2g {
+			label = "blue:wlan2g";
+			gpios = <&ath9k0 5 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wlan5g {
+			label = "blue:wlan5g";
+			gpios = <&ath9k1 5 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	rtl8366s {
+		compatible = "realtek,rtl8366s";
+		gpio-sda = <&gpio 5 GPIO_ACTIVE_HIGH>;
+		gpio-sck = <&gpio 7 GPIO_ACTIVE_HIGH>;
+		realtek,initvals = <0x06 0x0108>;
+
+		mdio-bus {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			phy-mask = <0x10>;
+
+			phy4: ethernet-phy@4 {
+				reg = <4>;
+				phy-mode = "rgmii";
+			};
+		};
+	};
+};
+
+&usb1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	usb_ohci_port: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};
+
+&usb2 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	usb_ehci_port: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&pcie0 {
+	status = "okay";
+
+	ath9k0: wifi@0,11 {
+		compatible = "pci168c,0029";
+		reg = <0x8800 0 0 0 0>;
+		qca,no-eeprom;
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+
+	ath9k1: wifi@0,12 {
+		compatible = "pci168c,0029";
+		reg = <0x9000 0 0 0 0>;
+		qca,no-eeprom;
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+};
+
+&pll {
+	clocks = <&extosc>;
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "config";
+				reg = <0x040000 0x010000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x050000 0x610000>;
+			};
+
+			partition@660000 {
+				label = "caldata";
+				reg = <0x660000 0x010000>;
+				read-only;
+			};
+
+			partition@670000 {
+				label = "unknown";
+				reg = <0x670000 0x190000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0x11110000 0x00001099 0x00991099>;
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&eth1 {
+	status = "okay";
+
+	pll-data = <0x11110000 0x00001099 0x00991099>;
+
+	phy-handle = <&phy4>;
+};
+

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -176,6 +176,7 @@ ath79_setup_interfaces()
 		;;
 	buffalo,wzr-hp-g300nh-rb|\
 	buffalo,wzr-hp-g300nh-s|\
+	trendnet,tew-673gru|\
 	dlink,dir-825-b1)
 		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \
@@ -583,6 +584,7 @@ ath79_setup_macs()
 	dlink,dap-3662-a1)
 		label_mac=$(mtd_get_mac_ascii bdcfg "wlanmac")
 		;;
+	trendnet,tew-673gru|\
 	dlink,dir-825-b1)
 		lan_mac=$(mtd_get_mac_text "caldata" 0xffa0)
 		wan_mac=$(mtd_get_mac_text "caldata" 0xffb4)

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -154,6 +154,7 @@ case "$FIRMWARE" in
 	buffalo,wzr-hp-ag300h)
 		caldata_extract "art" 0x1000 0xeb8
 		;;
+	trendnet,tew-673gru|\
 	dlink,dir-825-b1)
 		caldata_extract "caldata" 0x1000 0xeb8
 		ath9k_patch_mac_crc $(mtd_get_mac_text "caldata" 0xffa0) 0x20c
@@ -172,6 +173,7 @@ case "$FIRMWARE" in
 	buffalo,wzr-hp-ag300h)
 		caldata_extract "art" 0x5000 0xeb8
 		;;
+	trendnet,tew-673gru|\
 	dlink,dir-825-b1)
 		caldata_extract "caldata" 0x5000 0xeb8
 		ath9k_patch_mac_crc $(macaddr_add $(mtd_get_mac_text "caldata" 0xffb4) 1) 0x20c

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -2379,6 +2379,19 @@ define Device/teltonika_rut955-h7v3c0
 endef
 TARGET_DEVICES += teltonika_rut955-h7v3c0
 
+define Device/trendnet_tew-673gru
+  SOC := ar7161
+  DEVICE_VENDOR := Trendnet
+  DEVICE_MODEL := TEW-673GRU
+  DEVICE_VARIANT := v1.0R
+  IMAGE_SIZE := 6208k
+  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | \
+		check-size | append-metadata
+  DEVICE_PACKAGES := kmod-usb-ohci kmod-usb2 kmod-owl-loader
+  SUPPORTED_DEVICES += tew-673gru
+endef
+TARGET_DEVICES += trendnet_tew-673gru
+
 define Device/trendnet_tew-823dru
   SOC := qca9558
   DEVICE_VENDOR := Trendnet


### PR DESCRIPTION
Add support for the ar71xx supported TrendNet TEW-673GRU to ath79.
This is mostly a copy of D-Link DIR-825 B1.
Currently only sysupgrade, not factory build as the D-Link DIR-825 B1 only supports sysupgrade currently as well.

Signed-off-by: Korey Caro [korey.caro@gmail.com](mailto:korey.caro@gmail.com)